### PR TITLE
ui: Add small docs for the initial user flow

### DIFF
--- a/templates/firehose/drops/new.html
+++ b/templates/firehose/drops/new.html
@@ -18,7 +18,8 @@
 </form>
 
 <p>
-  Drag this to your bookmarks bar to easily add new drops to Firehose:
-  <a href="{{ bookmarklet }}">Add to Firehose</a>
+  Drag <a href="{{ bookmarklet }}">Add to Firehose</a> to your bookmarks bar to
+  easily add new drops. Click it when you're on any page to open this form with
+  the title and URL pre-filled.
 </p>
 {% endblock %}

--- a/templates/firehose/drops/new.html
+++ b/templates/firehose/drops/new.html
@@ -17,7 +17,7 @@
   </div>
 </form>
 
-<p>
+<p class="mt-4">
   Drag <a href="{{ bookmarklet }}">Add to Firehose</a> to your bookmarks bar to
   easily add new drops. Click it when you're on any page to open this form with
   the title and URL pre-filled.

--- a/templates/firehose/hydrants/index.html
+++ b/templates/firehose/hydrants/index.html
@@ -9,5 +9,25 @@
     {% endfor %}
   </ul>
 
-  <p><a href="{{ crate::controllers::hydrants::New.to_string() }}">New hydrant</a>
+  {% if hydrants.is_empty() %}
+    <p>You don't have any hydrants.</p>
+
+    <p>
+      A hydrant is a way to automatically add drops to Firehose. Right now, the
+      only kind of hydrant is an RSS/Atom feed.
+    </p>
+
+    <p>
+      Add a new RSS feed with the feed URL and name it whatever you like.
+      Firehose will automatically fetch that feed and add all of its items as
+      new drops.
+    </p>
+
+    <p>
+      If you add tags to the hydrant, all of its future drops will
+      automatically have those tags.
+    </p>
+  {% endif %}
+
+  <p><a href="{{ crate::controllers::hydrants::New.to_string() }}">New hydrant</a></p>
 {% endblock %}

--- a/templates/firehose/streams/index.html
+++ b/templates/firehose/streams/index.html
@@ -9,5 +9,20 @@
     {% endfor %}
   </ul>
 
-  <p><a href="{{ crate::controllers::streams::New.to_string() }}">New stream</a>
+  {% if streams.len() <= 3 %} {# only the three status streams #}
+    <p>You don't have any custom streams.</p>
+
+    <p>
+      A stream is a way to view filtered drops. The three default streams
+      filter by status, but you can add custom streams that filter by a set of
+      tags.
+    </p>
+
+    <p>
+      Create a new custom stream by choosing a name and a set of tags. Any drop
+      that matches any of these tags will be included in the stream.
+    </p>
+  {% endif %}
+
+  <p><a href="{{ crate::controllers::streams::New.to_string() }}">New stream</a></p>
 {% endblock %}

--- a/templates/firehose/tags/index.html
+++ b/templates/firehose/tags/index.html
@@ -15,5 +15,26 @@
     {% endfor %}
   </ul>
 
+  {% if tags.is_empty() %}
+  <p>You don't have any tags.</p>
+
+  <p>
+    When you
+    <a href="{{ crate::controllers::drops::New.to_string() }}">add a drop</a>,
+    you can apply tags to it. You can then filter drops by those tags.
+  </p>
+
+  <p>
+    You can create a
+    <a href="{{ crate::controllers::drops::Collection.to_string() }}">custom stream</a>
+    that shows drops matching a set of tags.
+  </p>
+
+  <p>
+    A set of tags can automatically be applied to all new drops created by a
+    <a href="{{ crate::controllers::hydrants::Collection.to_string() }}">hydrant</a>.
+  </p>
+  {% endif %}
+
   <p><a href="{{ crate::controllers::tags::New.to_string() }}">New tag</a>
 {% endblock %}


### PR DESCRIPTION
Thanks, @mitstud1993, for live-chatting your initial Firehose experience with me!

These are some quick documentation improvements to help new users figure out the app as they explore.

Itemized:
- [x] The bookmarklet instructions are unclear if you don't already know what it's supposed to do.
- [x] What's a Stream?
- [x] What's a Hydrant?
- [x] What's a Tag?

Screenshots:
![2023-03-14_23-22-58](https://user-images.githubusercontent.com/3269483/225224353-5f907703-c87c-44f9-bc9e-51b7cd70dffd.png)
![2023-03-14_23-23-09](https://user-images.githubusercontent.com/3269483/225224356-eca59f66-7334-46cb-9864-f6e5383198a3.png)
![2023-03-14_23-23-18](https://user-images.githubusercontent.com/3269483/225224357-4ac7af38-9523-4361-93df-ec98dcf18ade.png)
![2023-03-14_23-23-30](https://user-images.githubusercontent.com/3269483/225224360-2605b2e3-2113-47d0-ae5a-80bf942024f5.png)
